### PR TITLE
Center card content and style dates

### DIFF
--- a/components/BouncyBlogBubbles.tsx
+++ b/components/BouncyBlogBubbles.tsx
@@ -27,6 +27,7 @@ export default function BouncyBlogBubbles({ cards }: Props) {
       <div className="blog-bubbles-grid">
         {cards.map((c) => (
           <div key={c.id} className="blog-bubble-card" role="link" tabIndex={0} 
+               style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center' }}
                onClick={() => { audio.click(); window.open(c.url, '_blank', 'noopener'); }}
                onMouseEnter={(e) => {
                  (e.currentTarget as HTMLElement).style.transform = 'scale(1.05)';
@@ -37,7 +38,7 @@ export default function BouncyBlogBubbles({ cards }: Props) {
                  (e.currentTarget as HTMLElement).style.boxShadow = '0 4px 12px rgba(0,0,0,0.1)';
                }}>
             <div className="blog-bubble-title">{(c.title || '').toLowerCase()}</div>
-            {c.subtitle ? <div className="blog-bubble-sub">{c.subtitle}</div> : null}
+            {c.subtitle ? <div className="blog-bubble-sub" style={{ fontSize: '10px' }}>{c.subtitle}</div> : null}
           </div>
         ))}
       </div>


### PR DESCRIPTION
Center blog card contents and set date font size to 10px.

---
<a href="https://cursor.com/background-agent?bcId=bc-d435d4f3-69b4-463a-a1b5-59ab04855ab5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d435d4f3-69b4-463a-a1b5-59ab04855ab5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

